### PR TITLE
Convert OnAssist to function for compatibility with HadesSpeedrunningModpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # hades-RunHistoryWipe
-Mod for Hades by SuperGiant Games that wipes run history to prevent savefile hitching. Saves speed/heat records per aspect. To use, install (requires SGG `modimporter.py`, ModUtil, and HadesSpeedrunningModpack), enter game, visit the mod QoL menu page, and hit the reset button 5 times while in the House of Hades. Text should pop up over Zagreus's head saying your run history has been wiped.
+Mod for Hades by SuperGiant Games that wipes run history to prevent savefile hitching. Saves speed/heat records per aspect.
+
+# How to Use Mod: 
+- Install the modfile (requires SGG `modimporter.py`, ModUtil)
+- Enter courtyard in the House of Hades
+- Press the summon button five times
+    - alternatively, if you have the SpeedrunningModpack installed, open up the Quality of Life menu and press the reset button 5 times.
+- Text should pop up over Zagreus's head saying your run history has been wiped.
 
 NOTE: THIS IS PERMANENT - ALWAYS BACKUP YOUR OLD SAVE FILES JUST IN CASE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # hades-RunHistoryWipe
-Mod for Hades by SuperGiant Games that wipes run history to prevent savefile hitching. Saves speed/heat records per aspect. To use, install (requires SGG `modimporter.py` and ModUtil), enter game, and hit your summon button 5 times while in the House of Hades. Text should pop up over Zagreus's head saying your run history has been wiped.
+Mod for Hades by SuperGiant Games that wipes run history to prevent savefile hitching. Saves speed/heat records per aspect. To use, install (requires SGG `modimporter.py`, ModUtil, and HadesSpeedrunningModpack), enter game, visit the mod QoL menu page, and hit the reset button 5 times while in the House of Hades. Text should pop up over Zagreus's head saying your run history has been wiped.
 
 NOTE: THIS IS PERMANENT - ALWAYS BACKUP YOUR OLD SAVE FILES JUST IN CASE.

--- a/RunHistoryWipe.lua
+++ b/RunHistoryWipe.lua
@@ -8,20 +8,16 @@ RunHistoryWipe.Config = config
 RunHistoryWipe.AspectRecords = {}
 RunHistoryWipe.ConfirmButtonCount = 0
 
-OnControlPressed{ "Assist",
-    function( triggerArgs )
-        if ModUtil.PathGet("CurrentDeathAreaRoom") and IsEmpty( CurrentRun.Hero.FreezeInputKeys ) then
-            if RunHistoryWipe.ConfirmButtonCount < 4 and RunHistoryWipe.Config.Enabled then
-                RunHistoryWipe.ConfirmButtonCount = RunHistoryWipe.ConfirmButtonCount + 1
-            else
-                RunHistoryWipe.WipeRunHistory()
-                ModUtil.Hades.PrintOverhead("Run History Wiped!", 5)
-            end
+function RunHistoryWipe.PressWipeRunHistoryButton()
+    if ModUtil.PathGet("CurrentDeathAreaRoom") then
+        if RunHistoryWipe.ConfirmButtonCount < 4 and RunHistoryWipe.Config.Enabled then
+            RunHistoryWipe.ConfirmButtonCount = RunHistoryWipe.ConfirmButtonCount + 1
         else
-            ModUtil.Hades.PrintOverhead("Can't Wipe History Here...", 2)
+            RunHistoryWipe.WipeRunHistory()
+            ModUtil.Hades.PrintOverhead("Run History Wiped!", 5)
         end
     end
-}
+end
 
 function RunHistoryWipe.WipeRunHistory()
     GameState.ConsecutiveClears = 0
@@ -67,8 +63,6 @@ function RunHistoryWipe.WipeRunHistory()
     while TableLength(NewRunHistory) < 50 do
         table.insert(NewRunHistory, 1, {Cleared = true, RunDepthCache = 0})
     end
-
-    
 
     --NewRunHistory = ConcatTableValues(blank_runs, NewRunHistory)
     GameState.RunHistory = DeepCopyTable(NewRunHistory)

--- a/RunHistoryWipe.lua
+++ b/RunHistoryWipe.lua
@@ -19,6 +19,8 @@ function RunHistoryWipe.PressWipeRunHistoryButton()
     end
 end
 
+OnControlPressed{ "Assist", RunHistoryWipe.PressWipeRunHistoryButton }
+
 function RunHistoryWipe.WipeRunHistory()
     GameState.ConsecutiveClears = 0
     RunHistoryWipe.AspectRecords = {}


### PR DESCRIPTION
* Convert `On{"Assist", ...}` into a callable function for use with the HadesSpeedrunningModpack
* Remove unnecessary input-freeze check since you are frozen in the mod menu.